### PR TITLE
Add "generate json file per model" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ new Contentful({
 })
 ```
 
-This plugin ships with a default transform function that will run some basic cleanup. However, be warned that the transform will enter an infinite loop and crash if there are circular references within the data, which is not an uncommon occurance, so please be very careful utilizing this transform. The enable our default transform, you can pass `true` as such:
+This plugin ships with a default transform function that will run some basic cleanup. However, be warned that the transform will enter an infinite loop and crash if there are circular references within the data, which is not an uncommon occurance, so please be very careful utilizing this transform. To enable our default transform, you can pass `true` as such:
 
 ```js
 new Contentful({
@@ -149,6 +149,13 @@ new Contentful({
     }
   ]
 })
+```
+
+If you'd like to use our default transform outside of the library, this is also available as an export. For example, you could include it and use it with client-side JS responses.
+
+```js
+const Contentful = require('spike-contentful')
+console.log(Contentful.transform)
 ```
 
 ### Templates
@@ -196,11 +203,29 @@ new Contentful({
 })
 ```
 
-If you'd like to use our default transform outside of the library, this is also available as an export. For example, you could include it and use it with client-side JS responses.
+You may also choose to have the ouput written specifically for any content type :
 
 ```js
-const Contentful = require('spike-contentful')
-console.log(Contentful.transform)
+new Contentful({
+  addDataTo: locals,
+  accessToken: 'xxx',
+  spaceId: 'xxx'
+  contentTypes: [
+    {
+      name: 'posts',
+      id: '633fTeiMaxxxxxxxxx',
+      // JSON output expected for this content type
+      json: 'posts.json'
+    },
+    {
+      name: 'press',
+      id: '4Em9bQeIQxxxxxxxxx'
+      // No JSON output needed for this content type
+    }     
+  ],
+  // Save all content types data in one file
+  json: 'alldata.json'
+})
 ```
 
 ### Testing

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,12 +22,12 @@ class Contentful {
     compiler.plugin('watch-run', this.run.bind(this, compiler))
     compiler.plugin('emit', (compilation, done) => {
       if (this.json) {
-        const src = JSON.stringify(this.addDataTo.contentful, null, 2)
-        compilation.assets[this.json] = {
-          source: () => src,
-          size: () => src.length
-        }
+        writeJson(compilation, this.json, this.addDataTo.contentful)
       }
+
+      this.contentTypes.filter((ct) => ct.json).map((ct) => {
+        return writeJson(compilation, ct.json, this.addDataTo.contentful[ct.name])
+      })
 
       const templateContent = this.contentTypes.filter((ct) => {
         return ct.template
@@ -82,7 +82,8 @@ function validate (opts = {}) {
         filters: Joi.object().keys({
           limit: Joi.number().integer().min(1).max(100).default(100)
         }),
-        transform: Joi.alternatives().try(Joi.boolean(), Joi.func()).default(false)
+        transform: Joi.alternatives().try(Joi.boolean(), Joi.func()).default(false),
+        json: Joi.string()
       })
     )
   })
@@ -146,6 +147,14 @@ function extractMeta (sys) {
     if (sys[p]) m[p] = sys[p] // include only defined fields
     return m
   }, {})
+}
+
+function writeJson (compilation, filename, data) {
+  const src = JSON.stringify(data, null, 2)
+  compilation.assets[filename] = {
+    source: () => src,
+    size: () => src.length
+  }
 }
 
 function writeTemplate (ct, compiler, compilation, addDataTo, cb) {

--- a/test/fixtures/json/app.js
+++ b/test/fixtures/json/app.js
@@ -12,7 +12,8 @@ module.exports = {
     contentTypes: [
       {
         name: 'dogs',
-        id: 'dog'
+        id: 'dog',
+        json: 'dogs.json'
       }
     ],
     json: 'data.json'

--- a/test/index.js
+++ b/test/index.js
@@ -198,7 +198,7 @@ test.cb('works as a plugin to spike', (t) => {
   project.compile()
 })
 
-test.cb('writes json output', (t) => {
+test.cb('writes json outputs', (t) => {
   const projectPath = path.join(__dirname, 'fixtures/json')
   const project = new Spike({
     root: projectPath,
@@ -208,10 +208,14 @@ test.cb('writes json output', (t) => {
   project.on('error', t.end)
   project.on('warning', t.end)
   project.on('compile', () => {
-    const file = path.join(projectPath, 'public/data.json')
-    t.falsy(fs.accessSync(file))
-    const src = JSON.parse(fs.readFileSync(path.join(projectPath, 'public/data.json'), 'utf8'))
-    t.truthy(src.dogs.length > 1)
+    const globalFile = path.join(projectPath, 'public/data.json')
+    const specificFile = path.join(projectPath, 'public/dogs.json')
+    t.falsy(fs.accessSync(globalFile))
+    t.falsy(fs.accessSync(specificFile))
+    const srcGlobal = JSON.parse(fs.readFileSync(path.join(projectPath, 'public/data.json'), 'utf8'))
+    const srcSpecififc = JSON.parse(fs.readFileSync(path.join(projectPath, 'public/dogs.json'), 'utf8'))
+    t.truthy(srcGlobal.dogs.length === 2)
+    t.truthy(srcSpecififc.length === 2)
     rimraf.sync(path.join(projectPath, 'public'))
     t.end()
   })


### PR DESCRIPTION
Hello !
So here are the main caveats : 

- First of all, the code as I submited it doesn't manage situation where a same filename would be specified for different exports. Should this misuse error be handled ?

- I didn't define any `done()` callback for the new `W.map(jsonContent...` in `lib/index.js`. What's going on afterwards in the spike process is still a bit magic for me ;) Is it okay like this ?

- You will find some comments in `test/fixtures/json/app.js` & `test/index.js`. Indeed there's a bug in current data model : cat model canno't be exported in json as it generates an error 

```
Unhandled Rejection: test/index.js
  TypeError: Converting circular structure to JSON
    JSON.stringify (<anonymous>)
    writeJson (lib/index.js:157:20)
    Compiler.compiler.plugin (lib/index.js:25:9)
    Compiler.applyPluginsAsync (node_modules/tapable/lib/Tapable.js:71:13)
```

This error was already here in previous version of this module (i checked it) : if you try to test previous release by changing json export with cat instead of dog, the test will fail

Once this bug is closed, we will be able to remove comments and test that cats are in `data.json` but not in `dogs.json`
