### PR TITLE
Single page templated items now can use contentful

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,7 @@ class Contentful {
 
       // add a reshape multi option to compile each template separately
       options.multi = data.map((d) => {
-        return { locals: { item: d }, name: conf.template.output(d) }
+        return { locals: { item: d, contentful: this.addDataTo.contentful }, name: conf.template.output(d) }
       })
       return options
     })


### PR DESCRIPTION
Usecase: nav is global for all app pages ('single page templated' and not), generated with items pulled from a `contentful` object living in a template file as an `include`. Then the `contentful` object must be available in the single page template files via `locals` so that Spike could generate the nav inside.