### PR TITLE
Add `environment` option to Contentful connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module.exports = {
       addDataTo: locals,
       accessToken: 'xxx',
       spaceId: 'xxx',
+      environment: 'xxx',
       contentTypes: [
         {
           name: 'posts',
@@ -235,6 +236,22 @@ new Contentful({
   spaceId: 'xxx'
 })
 ```
+
+### Multiple Environments
+
+Using [Contentful's Environments](https://www.contentful.com/developers/docs/concepts/multiple-environments), you can specify different branches in a single space for staging and other environments:
+
+```js
+new Contentful({
+  addDataTo: locals,
+  accessToken: 'xxx',
+  preview: false;
+  spaceId: 'xxx',
+  environment: 'staging' // Or whatever your environment is called
+})
+```
+
+By default `environment` is set to `master`, which is provided with every Contentful space. For each environment you want to use, specify the name as it's provided in Contentful.
 
 ### JSON Output
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ class Contentful {
     this.client = contentful.createClient({
       accessToken: this.accessToken,
       space: this.spaceId,
-      host: this.preview ? 'preview.contentful.com' : ''
+      host: this.preview ? 'preview.contentful.com' : '',
+      environment: this.environment || 'master'
     })
     bindAllClass(this, ['apply', 'run'])
   }


### PR DESCRIPTION
This adds a new option to `contentful.createClient()` that allows for different environments to be specified. More info on environments [here](https://www.contentful.com/developers/docs/concepts/multiple-environments).

The default value is `master`, which is default in every Contentful space. Since environments can be named anything it's up to the user to specify the ID of any other environment.

Next steps:

1. Add tests